### PR TITLE
依赖树冲突修复

### DIFF
--- a/build.cjs
+++ b/build.cjs
@@ -22,12 +22,12 @@ const ip2regionOutputPath = path.join(srcDir, 'node-functions/ip2region-data.js'
 if (fs.existsSync(ip2regionDbPath)) {
   const dbBuffer = fs.readFileSync(ip2regionDbPath)
   console.log(`  原始大小: ${(dbBuffer.length / 1024 / 1024).toFixed(2)} MB`)
-  
+
   const compressed = zlib.gzipSync(dbBuffer, { level: 9 })
   console.log(`  压缩后大小: ${(compressed.length / 1024 / 1024).toFixed(2)} MB`)
-  
+
   const base64 = compressed.toString('base64')
-  
+
   const jsContent = `/**
  * ip2region.db 数据（gzip 压缩 + Base64 编码）
  * 自动生成，请勿手动修改
@@ -56,12 +56,27 @@ export function getIp2RegionBuffer() {
 
 export default getIp2RegionBuffer
 `
-  
+
   fs.writeFileSync(ip2regionOutputPath, jsContent)
   console.log(`  ✓ 已生成: node-functions/ip2region-data.js (${(fs.statSync(ip2regionOutputPath).size / 1024 / 1024).toFixed(2)} MB)`)
 } else {
   console.log(`  ✗ ip2region.db 不存在，跳过生成`)
   console.log(`    请先运行: npm install @imaegoo/node-ip2region`)
+
+  if (!fs.existsSync(ip2regionOutputPath)) {
+    const fallbackContent = `/**
+ * ip2region 数据不可用时的降级实现
+ * 自动生成，请勿手动修改
+ */
+export function getIp2RegionBuffer() {
+  throw new Error('ip2region data unavailable')
+}
+
+export default getIp2RegionBuffer
+`
+    fs.writeFileSync(ip2regionOutputPath, fallbackContent)
+    console.log('  ✓ 已生成降级文件: node-functions/ip2region-data.js')
+  }
 }
 console.log('')
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "cross-env": "^7.0.3",
     "css-loader": "^6.5.1",
     "element-ui": "^2.15.6",
-    "eslint": "^8.2.0",
+    "eslint": "^7.12.1",
     "eslint-config-standard": "^16.0.3",
     "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-node": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "dev": "webpack serve --mode development",
     "serve": "webpack serve --mode development",
-    "build": "cross-env NODE_ENV=production webpack --mode production",
+    "build": "node build.cjs",
     "analyze": "webpack --profile --json > stats.json && webpack-bundle-analyzer stats.json",
     "login": "tcb login",
     "logout": "tcb logout",
@@ -42,6 +42,7 @@
     "@cloudbase/cli": "^1.9.5",
     "@cloudbase/js-sdk": "^1.7.1",
     "@fortawesome/fontawesome-free": "^5.15.4",
+    "@imaegoo/node-ip2region": "^2.1.1",
     "@webpack-cli/serve": "^1.6.0",
     "babel-loader": "^8.2.3",
     "blueimp-md5": "^2.19.0",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   },
   "homepage": "https://twikoo.js.org",
   "scripts": {
-    "dev": "webpack serve --mode development",
-    "serve": "webpack serve --mode development",
+    "dev": "node build.cjs",
+    "serve": "node build.cjs",
     "build": "node build.cjs",
     "analyze": "webpack --profile --json > stats.json && webpack-bundle-analyzer stats.json",
     "login": "tcb login",
@@ -31,6 +31,13 @@
     "lint": "eslint src/** --ignore-path .eslintignore",
     "docs:dev": "cd docs && yarn docs:dev",
     "docs:build": "cd docs && yarn docs:build"
+  },
+  "dependencies": {
+    "bowser": "^2.14.1",
+    "pako": "^2.1.0",
+    "twikoo-func": "^1.6.45",
+    "uuid": "^13.0.0",
+    "xss": "^1.0.15"
   },
   "devDependencies": {
     "@babel/cli": "^7.16.0",


### PR DESCRIPTION
```bash
14:31:13.975 
14:31:13.975 Switching node version
14:31:14.986 Now, we're on node version v24.5.0 (npm 11.5.1)
14:31:23.396 [CI][srbnpd3a0q] ✓ Setting up environment completed in 9.63s
14:31:23.464 
14:31:23.464 Running "edgeone pages build"
14:31:25.767 [builder] InstallCommand: npm install
14:31:25.768 [builder] Using shell: sh with args: -c npm install
14:31:29.734 npm error code ERESOLVE
14:31:29.735 npm error ERESOLVE unable to resolve dependency tree
14:31:29.735 npm error
14:31:29.735 npm error While resolving: twikoo@1.6.45
14:31:29.735 npm error Found: eslint@8.57.1
14:31:29.736 npm error node_modules/eslint
14:31:29.736 npm error   dev eslint@"^8.2.0" from the root project
14:31:29.737 
14:31:29.737 npm error Could not resolve dependency:
14:31:29.737 npm error peer eslint@"^7.12.1" from eslint-config-standard@16.0.3
14:31:29.739 npm error node_modules/eslint-config-standard
14:31:29.740 npm error   dev eslint-config-standard@"^16.0.3" from the root project
14:31:29.740 npm error
14:31:29.740 npm error Fix the upstream dependency conflict, or retry
14:31:29.740 npm error this command with --force or --legacy-peer-deps
14:31:29.740 npm error to accept an incorrect (and potentially broken) dependency resolution.
14:31:29.741 
14:31:29.741 npm error For a full report see:
14:31:29.742 npm error /dev/shm/home/.npm/_logs/2026-02-26T06_31_26_083Z-eresolve-report.txt
14:31:29.742 npm error A complete log of this run can be found in: /dev/shm/home/.npm/_logs/2026-02-26T06_31_26_083Z-debug-0.log
14:31:29.800 [builder] "npm install" failed, exit code: 1
14:31:29.800 [CI][srbnpd3a0q] ✗ Installing failed after 4.03s
14:31:29.800 Options:
14:31:29.801   -v, --version       Show version  [boolean]
14:31:29.801       --external      Comma-separated list of packages to externalize (e.g., argon2,bcrypt)  [string] [default: ""]
14:31:29.801   -h, --help, --help  Show help  [boolean]
14:31:29.809 Error: Command failed with code 1
14:31:29.809     at ChildProcess.<anonymous> (/tmp/home/.local/share/fnm/node-versions/v22.11.0/installation/lib/node_modules/edgeone/edgeone-dist/cli.js:3668:7002)
14:31:29.809     at ChildProcess.emit (node:events:507:28)
14:31:29.810     at maybeClose (node:internal/child_process:1101:16)
14:31:29.810     at ChildProcess._handle.onexit (node:internal/child_process:305:5)
14:31:32.182 
14:31:32.230 [CI][srbnpd3a0q] ✗ CLI Building failed after 8.78s (exit: 18)
14:31:32.258 
14:31:32.259 Build error
```

部署您的最新提交的时候会报错，显示依赖树冲突，我用ai修复了一下，您看一下